### PR TITLE
fix(ci): correctly pass version output from release to publish-packag…

### DIFF
--- a/.github/workflows/utify.yml
+++ b/.github/workflows/utify.yml
@@ -84,6 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate
     if: startsWith(github.ref, 'refs/tags/v')
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
       - name: Get version
@@ -103,16 +105,14 @@ jobs:
             name=$(basename "$dir")
             go build -o "dist/examples/$name" "$dir"
           done
-      - name: Update GitHub Release
+      - name: Create or Update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get-version.outputs.version }}
           name: Release ${{ steps.get-version.outputs.version }}
           body: |
-            This release was updated with new build artifacts.
+            This release includes the latest built examples.
           files: dist/examples/*
-          draft: false
-          prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -133,4 +133,3 @@ jobs:
           GOPROXY=proxy.golang.org go list -m github.com/jsas4coding/utify@${VERSION}
       - name: Confirm publication
         run: echo "Release ${{ needs.release.outputs.version }} published successfully!"
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.4.6] - 2025-07-29
+
+### 🔧 Fixes
+
+- **CI/CD:** Corrected `release` job to export the version as an output for dependent jobs.
+- **Release Updates:** Ensured the GitHub release step can update existing releases with new artifacts.
+
+---
+
+## [1.4.5] - 2025-07-29
+
+### 🔧 Fixes
+
+- **Permissions:** Added `permissions: contents: write` to enable release updates.
+
+---
+
 ## [1.4.4] - 2025-07-29
 
 ### 🔧 Bug Fixes


### PR DESCRIPTION
…es job

- Added `outputs` to the release job in utify.yml to correctly export the version from the `get-version` step.
- Fixed the publish-packages job receiving an empty version string when publishing to the Go module proxy.
- Ensured that version information propagates across dependent jobs.